### PR TITLE
fix: add fs monitoring packages [TASK-4461]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ workflows:
                 - master
     jobs:
       - build:
+          name: nightly-build
           context: dockerhub
           publish: true
 
@@ -57,6 +58,7 @@ workflows:
     jobs:
       # Build-only on non-master branches
       - build:
+          name: build
           publish: false
           context: dockerhub
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,8 @@ workflows:
   # Publish builds on push to master
   on-push:
     jobs:
-      - docker/hadolint
+      - docker/hadolint:
+          ignore-rules: DL3018
 
       # Build-only on non-master branches
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,16 @@ jobs:
           tag: ${LATEST_RELEASE_VERSION}-alpine
       - when:
           condition:
-            equal: [true, << parameters.publish >>]
+            equal: [<< parameters.publish >>, false]
+          steps:
+            - run:
+                name: Save the image as an artifact
+                command: docker save verdigristech/pgbouncer:${LATEST_RELEASE_VERSION}-alpine | gzip > pgbouncer-${LATEST_RELEASE_VERSION}-alpine.tar.gz
+            - store_artifacts:
+                path: pgbouncer-${LATEST_RELEASE_VERSION}-alpine.tar.gz
+      - when:
+          condition:
+            equal: [<< parameters.publish >>, true]
           steps:
             - docker/push:
                 image: verdigristech/pgbouncer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2.1
+
+orbs:
+  docker: circleci/docker@2.6.0
+
+jobs:
+  build:
+    executor: docker/docker
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - docker/check:
+          docker-username: DOCKER_USERNAME
+          docker-password: DOCKER_PASSWORD
+      - run:
+          name: Find the latest release version and save to environment variables
+          command: |
+            export LATEST_RELEASE_VERSION=$(curl -s https://api.github.com/repos/pgbouncer/pgbouncer/releases/latest | jq -r '.tag_name | sub("pgbouncer_"; "") | sub("_"; "."; "g")')
+            echo "LATEST_RELEASE_VERSION=$LATEST_RELEASE_VERSION" >> $BASH_ENV
+      - docker/build:
+          extra_build_args: "--build-arg VERSION=$LATEST_RELEASE_VERSION"
+          image: verdigristech/pgbouncer
+          tag: ${LATEST_RELEASE_VERSION}-alpine
+      - docker/push:
+          image: verdigristech/pgbouncer
+          tag: ${LATEST_RELEASE_VERSION}-alpine
+
+workflows:
+  version: 2
+  nightly:
+    triggers:
+      - schedule:
+          # Run every day at 3:00 AM UTC
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: dockerhub
+  on-push:
+    jobs:
+      - build:
+          context: dockerhub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ orbs:
 
 jobs:
   build:
+    parameters:
+      publish:
+        type: boolean
+        default: false
     executor: docker/docker
     steps:
       - checkout
@@ -22,12 +26,18 @@ jobs:
           extra_build_args: "--build-arg VERSION=$LATEST_RELEASE_VERSION"
           image: verdigristech/pgbouncer
           tag: ${LATEST_RELEASE_VERSION}-alpine
-      - docker/push:
-          image: verdigristech/pgbouncer
-          tag: ${LATEST_RELEASE_VERSION}-alpine
+      - when:
+          condition:
+            equal: [true, << parameters.publish >>]
+          steps:
+            - docker/push:
+                image: verdigristech/pgbouncer
+                tag: ${LATEST_RELEASE_VERSION}-alpine
 
 workflows:
   version: 2
+
+  # Nightly publish builds
   nightly:
     triggers:
       - schedule:
@@ -40,7 +50,26 @@ workflows:
     jobs:
       - build:
           context: dockerhub
+          parameters:
+            publish: true
+
+  # Publish builds on push to master
   on-push:
     jobs:
+      # Build-only on non-master branches
       - build:
+          publish: false
           context: dockerhub
+          filters:
+            branches:
+              ignore: master
+
+      # Build and publish on master branch
+      - build:
+          name: publish
+          publish: true
+          context: dockerhub
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ jobs:
           steps:
             - run:
                 name: Save the image as an artifact
-                command: docker save verdigristech/pgbouncer:${LATEST_RELEASE_VERSION}-alpine | gzip > pgbouncer-${LATEST_RELEASE_VERSION}-alpine.tar.gz
+                command: |
+                  mkdir -p output
+                  docker save verdigristech/pgbouncer:${LATEST_RELEASE_VERSION}-alpine | gzip > output/pgbouncer-${LATEST_RELEASE_VERSION}-alpine.tar.gz
             - store_artifacts:
-                path: pgbouncer-${LATEST_RELEASE_VERSION}-alpine.tar.gz
+                path: output
       - when:
           condition:
             equal: [<< parameters.publish >>, true]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,20 +60,27 @@ workflows:
   # Publish builds on push to master
   on-push:
     jobs:
+      - docker/hadolint
+
       # Build-only on non-master branches
       - build:
           name: build
           publish: false
           context: dockerhub
+          requires:
+            - docker/hadolint
           filters:
             branches:
               ignore: master
+
 
       # Build and publish on master branch
       - build:
           name: publish
           publish: true
           context: dockerhub
+          requires:
+            - docker/hadolint
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,7 @@ workflows:
     jobs:
       - build:
           context: dockerhub
-          parameters:
-            publish: true
+          publish: true
 
   # Publish builds on push to master
   on-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ jobs:
             - docker/push:
                 image: verdigristech/pgbouncer
                 tag: ${LATEST_RELEASE_VERSION}-alpine
+            - docker/update-description:
+                docker-username: DOCKER_USERNAME
+                docker-password: DOCKER_PASSWORD
+                image: verdigristech/pgbouncer
 
 workflows:
   version: 2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+_Replace this text with a description of the changes in this Pull Request. Be sure to include the purpose of the changes, an overview of what changed, and any other relevant information._
+
+- _Summary item 1_
+- _Summary item 2_
+- _..._
+
+## Checklist
+
+- [ ] Pull Request title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) specification format: `type(scope): description`
+- [ ] Pull Request title is appended with Notion task ID in square brackets: `[TASK-123]`
+- [ ] Branch has been rebased against latest merge destination branch; this is typically `main` or `master`.
+- [ ] Linter ([Hadolint](https://hadolint.github.io/hadolint/)) has been applied on the code changes.
+- [ ] Documentation has been updated where necessary or comments were added where additional clarity is required.
+- [ ] Reviewer has been assigned to this Pull Request _**OR**_ is labeled with `hotfix`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,5 +55,5 @@ USER ${PGBOUNCER_UID}:${PGBOUNCER_GID}
 
 COPY default-pgbouncer.ini ${PGBOUNCER_CONFIG_DIR}/pgbouncer.ini
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--rewrite=15:2", "--"]
 CMD ["pgbouncer", "${PGBOUNCER_CONFIG_DIR}/pgbouncer.ini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.19.1 AS builder
 ARG VERSION=1.21.0
 
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk --update add \
     coreutils \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,11 @@ COPY --from=builder /usr/local/bin/pgbouncer /usr/local/bin/pgbouncer
 RUN \
   # Ensure busybox is upgraded to latest version for security reasons
   apk add -U --no-cache --upgrade busybox \
-  # PgBouncer library dependencies
-  && apk add -U --no-cache c-ares dumb-init libevent postgresql15-client \
+  && apk add -U --no-cache \
+    # PgBouncer library dependencies
+    c-ares dumb-init libevent postgresql15-client \
+    # Filesystem monitoring tools
+    inotify-tools procps-ng \
   # Create config and log directories
   && mkdir -p $PGBOUNCER_CONFIG_DIR $PGBOUNCER_LOG_DIR \
   && chmod -R 755 $PGBOUNCER_LOG_DIR \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.19.1 AS builder
 ARG VERSION=1.21.0
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN apk --update add \
+RUN apk --no-cache --update add \
     coreutils \
     curl \
     build-base \
@@ -19,10 +19,10 @@ RUN curl -sSL https://pgbouncer.github.io/downloads/files/${VERSION}/pgbouncer-$
 
 WORKDIR /tmp/pgbouncer-${VERSION}
 
-RUN ./autogen.sh
-RUN ./configure --prefix=/usr/local
-RUN make
-RUN make install
+RUN ./autogen.sh \
+  && ./configure --prefix=/usr/local \
+  && make \
+  && make install
 
 FROM alpine:3.19.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.4 AS builder
+FROM alpine:3.19.1 AS builder
 ARG VERSION=1.21.0
 
 RUN apk --update add \
@@ -23,7 +23,7 @@ RUN ./configure --prefix=/usr/local
 RUN make
 RUN make install
 
-FROM alpine:3.18.4
+FROM alpine:3.19.1
 
 LABEL maintainer="Verdigris Technologies <infrastructure@verdigris.co>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,16 +41,16 @@ RUN \
   # Ensure busybox is upgraded to latest version for security reasons
   apk add -U --no-cache --upgrade busybox \
   # PgBouncer library dependencies
-  && apk add -U --no-cache c-ares dumb-init libevent postgresql15-client
-
-RUN mkdir -p $PGBOUNCER_CONFIG_DIR $PGBOUNCER_LOG_DIR
-RUN chmod -R 755 $PGBOUNCER_LOG_DIR
-
-RUN addgroup -g ${PGBOUNCER_GID} ${PGBOUNCER_GROUP} \
-  && adduser -D -u ${PGBOUNCER_UID} -G ${PGBOUNCER_GROUP} ${PGBOUNCER_USER}
-
-RUN chown -R $PGBOUNCER_USER:$PGBOUNCER_GROUP $PGBOUNCER_CONFIG_DIR
-RUN chown -R $PGBOUNCER_USER:$PGBOUNCER_GROUP $PGBOUNCER_LOG_DIR
+  && apk add -U --no-cache c-ares dumb-init libevent postgresql15-client \
+  # Create config and log directories
+  && mkdir -p $PGBOUNCER_CONFIG_DIR $PGBOUNCER_LOG_DIR \
+  && chmod -R 755 $PGBOUNCER_LOG_DIR \
+  # Create pgbouncer user and group
+  && addgroup -g ${PGBOUNCER_GID} ${PGBOUNCER_GROUP} \
+  && adduser -D -u ${PGBOUNCER_UID} -G ${PGBOUNCER_GROUP} ${PGBOUNCER_USER} \
+  # Update ownership of config and log directories
+  && chown -R $PGBOUNCER_USER:$PGBOUNCER_GROUP $PGBOUNCER_CONFIG_DIR \
+  && chown -R $PGBOUNCER_USER:$PGBOUNCER_GROUP $PGBOUNCER_LOG_DIR
 
 USER ${PGBOUNCER_UID}:${PGBOUNCER_GID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,8 @@ COPY --from=builder /usr/local/bin/pgbouncer /usr/local/bin/pgbouncer
 RUN \
   # Ensure busybox is upgraded to latest version for security reasons
   apk add -U --no-cache --upgrade busybox \
-  && apk add -U --no-cache \
-    # PgBouncer library dependencies
-    c-ares dumb-init libevent postgresql15-client \
-    # Filesystem monitoring tools
-    inotify-tools procps-ng \
+  # PgBouncer library dependencies
+  && apk add -U --no-cache c-ares dumb-init libevent postgresql15-client \
   # Create config and log directories
   && mkdir -p $PGBOUNCER_CONFIG_DIR $PGBOUNCER_LOG_DIR \
   && chmod -R 755 $PGBOUNCER_LOG_DIR \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,6 @@ USER ${PGBOUNCER_UID}:${PGBOUNCER_GID}
 
 COPY default-pgbouncer.ini ${PGBOUNCER_CONFIG_DIR}/pgbouncer.ini
 
+# Rewrite SIGTERM to SIGINT to allow graceful shutdown in PgBouncer
 ENTRYPOINT ["/usr/bin/dumb-init", "--rewrite=15:2", "--"]
 CMD ["pgbouncer", "${PGBOUNCER_CONFIG_DIR}/pgbouncer.ini"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # docker-pgbouncer
+
 PgBouncer container based on Alpine Linux
+
+## Specifying PgBouncer version
+
+To build the image with a new PgBouncer version, you can use the `--build-arg`
+option to specify the version you want to use. For example, to build the image
+with PgBouncer 1.21.0, you can run the following command:
+
+```bash
+docker build --build-arg VERSION=1.21.0 -t verdigristech/pgbouncer:1.21.0 .
+```

--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@
 
 PgBouncer container based on Alpine Linux
 
-## Specifying PgBouncer version
+## Building the image
+
+### Specifying the PgBouncer version
 
 To build the image with a new PgBouncer version, you can use the `--build-arg`
 option to specify the version you want to use. For example, to build the image
 with PgBouncer 1.21.0, you can run the following command:
 
 ```bash
-docker build --build-arg VERSION=1.21.0 -t verdigristech/pgbouncer:1.21.0 .
+docker build --build-arg VERSION=1.22.0 -t verdigristech/pgbouncer:1.22.0-alpine .
 ```
+
+---
+
+© 2017 - 2024 Verdigris Technologies, Inc. All rights reserved.
 
 [snyk]: https://snyk.io/test/github/verdigristech/docker-pgbouncer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker-pgbouncer
 
+![Docker Image Size][shield-docker-image-size]
+![Docker Pulls][shield-docker-pulls]
 [![Known Vulnerabilities](https://snyk.io/test/github/verdigristech/docker-pgbouncer/badge.svg)][snyk]
 
 PgBouncer container based on Alpine Linux
@@ -20,4 +22,6 @@ docker build --build-arg VERSION=1.22.0 -t verdigristech/pgbouncer:1.22.0-alpine
 
 © 2017 - 2024 Verdigris Technologies, Inc. All rights reserved.
 
+[shield-docker-image-size]: https://img.shields.io/docker/image-size/verdigristech/pgbouncer
+[shield-docker-pulls]: https://img.shields.io/docker/pulls/verdigristech/pgbouncer
 [snyk]: https://snyk.io/test/github/verdigristech/docker-pgbouncer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker-pgbouncer
 
+[![Known Vulnerabilities](https://snyk.io/test/github/verdigristech/docker-pgbouncer/badge.svg)][snyk]
+
 PgBouncer container based on Alpine Linux
 
 ## Specifying PgBouncer version
@@ -11,3 +13,5 @@ with PgBouncer 1.21.0, you can run the following command:
 ```bash
 docker build --build-arg VERSION=1.21.0 -t verdigristech/pgbouncer:1.21.0 .
 ```
+
+[snyk]: https://snyk.io/test/github/verdigristech/docker-pgbouncer


### PR DESCRIPTION
## Summary

- Docker container image has been updated:
  - Adds `inotify-tools` and `procps-ng` packages which will be needed in Kubernetes environment to watch for file system changes and send a proper SIGHUP signal
  - Upgraded to Alpine Linux 3.19 to address supply chain security vulnerabilities
  - Modified to conform to hadolint rules
  - Rewrite SIGTERM to SIGINT to handle graceful shutdown
- Add CI/CD pipeline
- Update README
- Add PR template

## Checklist

- [x] Pull Request title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) specification format: `type(scope): description`
- [x] Pull Request title is appended with Notion task ID in square brackets: `[TASK-123]`
- [x] Branch has been rebased against latest merge destination branch; this is typically `main` or `master`.
- [x] Linter ([Hadolint](https://hadolint.github.io/hadolint/)) has been applied on the code changes.
- [x] Documentation has been updated where necessary or comments were added where additional clarity is required.
- [x] Reviewer has been assigned to this Pull Request _**OR**_ is labeled with `hotfix`.
